### PR TITLE
Fixed EXP Curve, Fixed Mod detection for RSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _ReSharper*/
 _releases/Debug/*
 /UpgradeLog.htm
 /Backup
+/_releases/Release

--- a/BinningSkill/Core/ModEntry.cs
+++ b/BinningSkill/Core/ModEntry.cs
@@ -15,11 +15,11 @@ namespace BinningSkill
         internal static Config Config;
         internal static Assets Assets;
 
-        internal static bool RSVLoaded;
-        internal static bool AutomateLoaded;
-        internal static bool JALoaded;
-        internal static bool DGALoaded;
-        internal static bool MargoLoaded;
+        internal static bool RSVLoaded => ModEntry.Instance.Helper.ModRegistry.IsLoaded("Rafseazz.RidgesideVillage");
+        internal static bool AutomateLoaded => ModEntry.Instance.Helper.ModRegistry.IsLoaded("Pathoschild.Automate");
+        internal static bool JALoaded => ModEntry.Instance.Helper.ModRegistry.IsLoaded("spacechase0.JsonAssets");
+        internal static bool DGALoaded => ModEntry.Instance.Helper.ModRegistry.IsLoaded("spacechase0.DynamicGameAssets");
+        internal static bool MargoLoaded => ModEntry.Instance.Helper.ModRegistry.IsLoaded("DaLion.Overhaul");
 
         internal static IJsonAssetsApi JsonAssets;
         internal static IDynamicGameAssetsApi DynamicGameAssets;
@@ -47,11 +47,6 @@ namespace BinningSkill
             new Harmony(this.ModManifest.UniqueID).PatchAll();
             new CommandClassParser(this.Helper.ConsoleCommands, new Command()).ParseCommands();
 
-            RSVLoaded = this.Helper.ModRegistry.IsLoaded("Rafseazz.RidgesideVillage");
-            AutomateLoaded = this.Helper.ModRegistry.IsLoaded("Pathoschild.Automate");
-            JALoaded = this.Helper.ModRegistry.IsLoaded("spacechase0.JsonAssets");
-            DGALoaded = this.Helper.ModRegistry.IsLoaded("spacechase0.DynamicGameAssets");
-            MargoLoaded = this.Helper.ModRegistry.IsLoaded("DaLion.Overhaul");
 
             // Register binning skill after checking if MARGO is loaded.
             SpaceCore.Skills.RegisterSkill(new BinningSkill());

--- a/BinningSkill/Objects/BinningSkill.cs
+++ b/BinningSkill/Objects/BinningSkill.cs
@@ -20,7 +20,7 @@ namespace BinningSkill
 
             if (ModEntry.MargoLoaded)
             {
-                this.ExperienceCurve = new[] { 100, 300, 770, 1300, 2150, 3300, 4000, 6900, 10000, 15000, 20000, 25000, 30000, 35000, 40000, 45000, 50000, 55000, 60000, 70000 };
+                this.ExperienceCurve = new[] { 100, 380, 770, 1300, 2150, 3300, 4000, 6900, 10000, 15000, 20000, 25000, 30000, 35000, 40000, 45000, 50000, 55000, 60000, 70000 };
                 this.AddProfessions(
                     Recycler = new KeyedProfession(this, "Recycler", ModEntry.Assets.Recycler, ModEntry.Assets.RecyclerP, ModEntry.Instance.Helper),
                     Sneak = new KeyedProfession(this, "Sneak", ModEntry.Assets.Sneak, ModEntry.Assets.SneakP, ModEntry.Instance.Helper),
@@ -32,7 +32,7 @@ namespace BinningSkill
             }
             else
             {
-                this.ExperienceCurve = new[] { 100, 300, 770, 1300, 2150, 3300, 4000, 6900, 10000, 15000 };
+                this.ExperienceCurve = new[] { 100, 380, 770, 1300, 2150, 3300, 4000, 6900, 10000, 15000 };
                 this.AddProfessions(
                     Recycler = new KeyedProfession(this, "Recycler", ModEntry.Assets.Recycler, ModEntry.Instance.I18n),
                     Sneak = new KeyedProfession(this, "Sneak", ModEntry.Assets.Sneak, ModEntry.Instance.I18n),


### PR DESCRIPTION
Because 'RSVLoaded' checked after the harmony patches, it always returned false and thus never loaded. Moved to checking before harmony tries to patch.

Also fixed the exp curve.